### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ see `.env-example`
 ```java
 # Used by Prisma:
 #   url = env("POSTGRES_PRISMA_URL") // uses connection pooling
-#   directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-#   shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
+#   directUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
 
 # Create a Postgres database on Vercel: https://vercel.com/postgres
 POSTGRES_PRISMA_URL=


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.